### PR TITLE
Send DDLs to the right catalog.

### DIFF
--- a/be/src/catalog/catalog-server.cc
+++ b/be/src/catalog/catalog-server.cc
@@ -300,20 +300,21 @@ void CatalogServer::UpdateCatalogMembershipCallback(
         LOG(INFO) << "VIHANG-DEBUG: Membership topic didn't contain any deltas";
         return;
     } else {
-        const TTopicDelta& update = topic->second;
-        if (!update.topic_entries.empty()) {
-            for (const TTopicItem& item : update.topic_entries) {
-                //LOG(INFO) << "VIHANG-DEBUG: Item key: " << item.key << " value: " << item.value;
-                TUpdateRingNodeRequest req;
-                req.removed = false;
-                // need to decide if we want to use serviceUrl or serviceId
-                req.serviceId = item.key;
-                Status s = catalog_->UpdateRingNode(req);
-                if (!s.ok()) {
-                    LOG(ERROR) << "Failed the update the consistent hash ring for " << item.key;
-                }
-            }
-        } else {
+      const TTopicDelta& update = topic->second;
+      if (!update.topic_entries.empty()) {
+        for (const TTopicItem& item : update.topic_entries) {
+          // LOG(INFO) << "VIHANG-DEBUG: Item key: " << item.key << " value: " <<
+          // item.value;
+          TUpdateRingNodeRequest req;
+          req.removed = false;
+          // need to decide if we want to use serviceUrl or serviceId
+          req.serviceId = item.key;
+          Status s = catalog_->UpdateRingNode(req);
+          if (!s.ok()) {
+            LOG(ERROR) << "Failed the update the consistent hash ring for " << item.key;
+          }
+        }
+      } else {
             LOG(INFO) << "VIHANG-DEBUG: topic entries is empty";
         }
         //LOG(INFO) << "VIHANG-DEBUG: Received cluster membership update";
@@ -333,7 +334,7 @@ void CatalogServer::AddCatalogServerStatusToStatestore(vector<TTopicDelta>* subs
 
     TTopicItem& item = update.topic_entries.back();
     TNetworkAddress server_address = MakeNetworkAddress(FLAGS_hostname,
-                                                        FLAGS_catalog_service_port);
+        FLAGS_catalog_service_port);
     string itemKey = TNetworkAddressToString(server_address);
     item.key = itemKey;
     item.value = itemKey;

--- a/be/src/catalog/catalog-server.h
+++ b/be/src/catalog/catalog-server.h
@@ -59,7 +59,6 @@ class Catalog;
 class CatalogServer {
  public:
   static std::string IMPALA_CATALOG_TOPIC;
-  static std::string IMPALA_CATALOG_MEMBERSHIP_TOPIC;
   CatalogServer(MetricGroup* metrics);
 
   /// Starts this CatalogService instance.

--- a/common/thrift/CatalogService.thrift
+++ b/common/thrift/CatalogService.thrift
@@ -185,6 +185,9 @@ struct TDdlExecResponse {
   // created table. This is useful for establishing lineage between table and it's
   // location for external tables.
   6: optional string table_location
+
+  // If this is set, coordinator should resend the DDL request to this catalog.
+  7: optional string catalog_address
 }
 
 // Updates the metastore with new partition information and returns a response

--- a/fe/src/main/java/org/apache/impala/catalog/CatalogServiceCatalog.java
+++ b/fe/src/main/java/org/apache/impala/catalog/CatalogServiceCatalog.java
@@ -2986,6 +2986,13 @@ public class CatalogServiceCatalog extends Catalog {
   }
 
   /**
+   * Returns the catalog network address.
+   */
+  public String getCatalogServiceAddress() {
+    return catalogServiceAddress_;
+  }
+
+  /**
    * Returns the number of currently running partial RPCs.
    */
   @VisibleForTesting


### PR DESCRIPTION
Currently added for create table. Tested manually by creating
different tables. DDL requests are always sent to only one
catalog which responds with the right address and the operation
is retried on that new catalog.

Change-Id: Id34d4e50cd238ebce2a25898ed40aa5d40207619